### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ ELSE()
 ENDIF()
 
 add_application(MacHTTPTest
-	MacHTTPTest.cpp
+	MacHttpTest.cpp
 	size.r
 	CONSOLE
 )


### PR DESCRIPTION
build fix. Cmake was failing on filesystems with case sensitivity because the file in the github archive is MacHttpTest.cpp but cmake is looking for MacHTTPTest.cpp