### PR TITLE
fix: compilation issue with stdexcept

### DIFF
--- a/HttpClient.cpp
+++ b/HttpClient.cpp
@@ -2,7 +2,7 @@
 #include <string.h>
 #include "HttpClient.h"
 #include <stdio.h>
-#include <stdexcept.h>
+#include <stdexcept>
 
 extern "C"
 {

--- a/HttpClient.cpp
+++ b/HttpClient.cpp
@@ -2,6 +2,7 @@
 #include <string.h>
 #include "HttpClient.h"
 #include <stdio.h>
+#include <stdexcept.h>
 
 extern "C"
 {


### PR DESCRIPTION
HttpClient.cpp needs to add `#include <stdexcept>`

```
/Users/contra/Projects/macintosh/code/claude/libs/machttp/HttpClient.cpp: In member function ‘void HttpClient::Get(const std::string&, std::function<void(HttpResponse&)>)’:
/Users/contra/Projects/macintosh/code/claude/libs/machttp/HttpClient.cpp:41:22: error: ISO C++ forbids declaration of ‘invalid_argument’ with no type [-fpermissive]
   41 |         catch (const invalid_argument& e)
      |                      ^~~~~~~~~~~~~~~~
/Users/contra/Projects/macintosh/code/claude/libs/machttp/HttpClient.cpp:41:38: error: expected ‘)’ before ‘&’ token
   41 |         catch (const invalid_argument& e)
      |               ~                      ^
      |                                      )
/Users/contra/Projects/macintosh/code/claude/libs/machttp/HttpClient.cpp:41:38: error: expected ‘{’ before ‘&’ token
/Users/contra/Projects/macintosh/code/claude/libs/machttp/HttpClient.cpp:41:40: error: ‘e’ was not declared in this scope
   41 |         catch (const invalid_argument& e)
      |                                        ^
/Users/contra/Projects/macintosh/code/claude/libs/machttp/HttpClient.cpp: In member function ‘void HttpClient::Post(const std::string&, const std::string&, std::function<void(HttpResponse&)>)’:
/Users/contra/Projects/macintosh/code/claude/libs/machttp/HttpClient.cpp:68:22: error: ISO C++ forbids declaration of ‘invalid_argument’ with no type [-fpermissive]
   68 |         catch (const invalid_argument& e)
      |                      ^~~~~~~~~~~~~~~~
/Users/contra/Projects/macintosh/code/claude/libs/machttp/HttpClient.cpp:68:38: error: expected ‘)’ before ‘&’ token
   68 |         catch (const invalid_argument& e)
      |               ~                      ^
      |                                      )
/Users/contra/Projects/macintosh/code/claude/libs/machttp/HttpClient.cpp:68:38: error: expected ‘{’ before ‘&’ token
/Users/contra/Projects/macintosh/code/claude/libs/machttp/HttpClient.cpp:68:40: error: ‘e’ was not declared in this scope
   68 |         catch (const invalid_argument& e)
      |                                        ^
make[3]: *** [CMakeFiles/MacHTTP.dir/HttpClient.cpp.obj] Error 1
make[2]: *** [CMakeFiles/MacHTTP.dir/all] Error 2
make[1]: *** [all] Error 2
make: *** [build-machttp] Error 2
```